### PR TITLE
Dynamic extension not working for queries nor standalone programs

### DIFF
--- a/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/AcceleoEnginePlugin.java
+++ b/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/AcceleoEnginePlugin.java
@@ -161,6 +161,13 @@ public class AcceleoEnginePlugin extends Plugin {
 	public void start(final BundleContext context) throws Exception {
 		plugin = this;
 		super.start(context);
+		parseExtensionPoints();
+	}
+
+	/**
+	 * Parse extension points
+	 */
+	public void parseExtensionPoints() {
 		final IExtensionRegistry registry = Platform.getExtensionRegistry();
 		registry.addListener(dynamicTemplatesListener,
 				DynamicTemplatesRegistryListener.DYNAMIC_TEMPLATES_EXTENSION_POINT);

--- a/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/internal/utils/AcceleoDynamicTemplatesEclipseUtil.java
+++ b/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/internal/utils/AcceleoDynamicTemplatesEclipseUtil.java
@@ -117,6 +117,16 @@ public final class AcceleoDynamicTemplatesEclipseUtil {
 	}
 
 	/**
+	 * Returns all registered modules. The returned set is a copy of this instance's.
+	 * 
+	 * @return A copy of the registered modules set.
+	 */
+	public static Set<DynamicModuleContribution> getRegisteredModules() {
+		refreshModules(null);
+		return new CompactLinkedHashSet<DynamicModuleContribution>(REGISTERED_MODULES);
+	}
+
+	/**
 	 * This will be called prior to all invocations of getRegisteredModules so as to be aware of new additions
 	 * or removals of dynamic templates.
 	 * 
@@ -183,22 +193,14 @@ public final class AcceleoDynamicTemplatesEclipseUtil {
 					return;
 				}
 				try {
-					List<File> modules = new ArrayList<File>();
+					List<URL> modules = new ArrayList<URL>();
 					while (emtlFiles.hasMoreElements()) {
 						final URL next = emtlFiles.nextElement();
 						if (actualPath == pathSeparator) {
 							final File moduleFile = new File(FileLocator.toFileURL(next).getFile());
-							if (!moduleFile.isDirectory() && moduleFile.exists() && moduleFile.canRead()) {
-								modules.add(moduleFile);
-							}
+							modules.add(next);
 						} else {
-							String emtlPath = next.getPath();
-							if (emtlPath.substring(0, emtlPath.lastIndexOf('/')).contains(actualPath)) {
-								final File moduleFile = new File(FileLocator.toFileURL(next).getFile());
-								if (!moduleFile.isDirectory() && moduleFile.exists() && moduleFile.canRead()) {
-									modules.add(moduleFile);
-								}
-							}
+							modules.add(next);
 						}
 					}
 					REGISTERED_MODULES.add(new DynamicModuleContribution(descriptor.getGeneratorIDs(),
@@ -212,4 +214,5 @@ public final class AcceleoDynamicTemplatesEclipseUtil {
 			EXTENDING_BUNDLES.remove(uninstalledBundle);
 		}
 	}
+
 }

--- a/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/internal/utils/DynamicModuleContribution.java
+++ b/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/internal/utils/DynamicModuleContribution.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.acceleo.engine.internal.utils;
 
-import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +28,7 @@ public class DynamicModuleContribution {
 	/**
 	 * The module files.
 	 */
-	private List<File> files = new ArrayList<File>();
+	private List<URL> files = new ArrayList<URL>();
 
 	/**
 	 * The constructor.
@@ -38,7 +38,7 @@ public class DynamicModuleContribution {
 	 * @param files
 	 *            The files of the dynamic modules.
 	 */
-	public DynamicModuleContribution(List<String> generatorIDs, List<File> files) {
+	public DynamicModuleContribution(List<String> generatorIDs, List<URL> files) {
 		this.generatorIDs = generatorIDs;
 		this.files = files;
 	}
@@ -57,7 +57,7 @@ public class DynamicModuleContribution {
 	 * 
 	 * @return The files of the dynamic modules.
 	 */
-	public List<File> getFiles() {
+	public List<URL> getFiles() {
 		return files;
 	}
 }

--- a/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/internal/utils/DynamicTemplatesRegistryListener.java
+++ b/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/internal/utils/DynamicTemplatesRegistryListener.java
@@ -10,16 +10,38 @@
  *******************************************************************************/
 package org.eclipse.acceleo.engine.internal.utils;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IContributor;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IRegistryEventListener;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.emf.common.util.URI;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
 
 /**
  * This listener will allow us to be aware of contribution changes against the dynamic templates extension
@@ -121,15 +143,241 @@ public final class DynamicTemplatesRegistryListener implements IRegistryEventLis
 				}
 			}
 		}
-		final Bundle bundle = Platform.getBundle(extension.getContributor().getName());
+		Bundle bundle = Platform.getBundle(extension.getContributor().getName());
 		// If bundle is null, the bundle id is different than its name.
 		if (bundle != null) {
 			if (paths.size() == 0) {
 				paths.add("/"); //$NON-NLS-1$
 			}
-			AcceleoDynamicModulesDescriptor acceleoDynamicModulesDescriptor = new AcceleoDynamicModulesDescriptor(
-					generators, paths);
-			AcceleoDynamicTemplatesEclipseUtil.addExtendingBundle(bundle, acceleoDynamicModulesDescriptor);
+		} else {
+			bundle = new BundleAdapter(extension.getContributor());
+		}
+		AcceleoDynamicModulesDescriptor acceleoDynamicModulesDescriptor = new AcceleoDynamicModulesDescriptor(
+				generators, paths);
+		AcceleoDynamicTemplatesEclipseUtil.addExtendingBundle(bundle, acceleoDynamicModulesDescriptor);
+	}
+
+	protected class BundleAdapter implements Bundle {
+
+		private IContributor contributor;
+
+		public BundleAdapter(IContributor contributor) {
+			this.contributor = contributor;
+		}
+
+		public int compareTo(Bundle o) {
+			return 0;
+		}
+
+		public int getState() {
+			return 0;
+		}
+
+		public void start(int options) throws BundleException {
+
+		}
+
+		public void start() throws BundleException {
+
+		}
+
+		public void stop(int options) throws BundleException {
+
+		}
+
+		public void stop() throws BundleException {
+
+		}
+
+		public void update(InputStream input) throws BundleException {
+
+		}
+
+		public void update() throws BundleException {
+
+		}
+
+		public void uninstall() throws BundleException {
+
+		}
+
+		public Dictionary<String, String> getHeaders() {
+			return null;
+		}
+
+		public long getBundleId() {
+			return 0;
+		}
+
+		public String getLocation() {
+			return null;
+		}
+
+		public ServiceReference<?>[] getRegisteredServices() {
+			return null;
+		}
+
+		public ServiceReference<?>[] getServicesInUse() {
+			return null;
+		}
+
+		public boolean hasPermission(Object permission) {
+			return false;
+		}
+
+		public URL getResource(String name) {
+			return null;
+		}
+
+		public Dictionary<String, String> getHeaders(String locale) {
+			return null;
+		}
+
+		public String getSymbolicName() {
+			return null;
+		}
+
+		public Class<?> loadClass(String name) throws ClassNotFoundException {
+			return null;
+		}
+
+		public Enumeration<URL> getResources(String name) throws IOException {
+			return null;
+		}
+
+		public Enumeration<String> getEntryPaths(String path) {
+			return null;
+		}
+
+		public URL getEntry(String path) {
+			return null;
+		}
+
+		public long getLastModified() {
+			return 0;
+		}
+
+		public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
+			String pluginID = contributor.getName();
+			URI plPath = org.eclipse.emf.ecore.resource.URIConverter.URI_MAP.get(URI.createURI(
+					"platform:/plugin/" + pluginID + "/"));
+			if (plPath == null) {
+				plPath = org.eclipse.emf.ecore.resource.URIConverter.URI_MAP.get(URI.createURI(
+						"platform:/resource/" + pluginID + "/"));
+			}
+			if (plPath == null) {
+				return null;
+			}
+			Collection<URL> ret = null;
+			if (plPath.isFile()) {
+				ret = findResourceRecursive(new File(plPath.toFileString()), filePattern, recurse);
+			} else if (plPath.isArchive() && "jar".equals(plPath.scheme())) {
+				URL url;
+				try {
+					url = new URL(plPath.toString());
+					JarURLConnection urlcon = (JarURLConnection)url.openConnection();
+					JarFile jarFile = urlcon.getJarFile();
+					ret = findResourceInJar(url, jarFile, filePattern);
+				} catch (MalformedURLException e) {
+					throw new RuntimeException(e);
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+
+			return new VectorEnumeration<URL>(ret);
+		}
+
+		private Collection<URL> findResourceInJar(URL jarUrl, JarFile jarFile, String filePattern)
+				throws MalformedURLException {
+			Vector<URL> out = new Vector<URL>();
+			Enumeration<JarEntry> entries = jarFile.entries();
+			String regex = filePattern.substring(1);
+			while (entries.hasMoreElements()) {
+				JarEntry entry = entries.nextElement();
+
+				if (entry.getName().endsWith(regex)) {
+					out.add(new URL(jarUrl + entry.getName()));
+				}
+			}
+			return out;
+		}
+
+		private final Collection<URL> findResourceRecursive(File libFolder, String regex, boolean recurse) {
+			Vector<URL> out = new Vector<URL>();
+
+			File[] jars = libFolder.listFiles(new RegexFileFilter(regex));
+			for (File file : jars) {
+				try {
+					out.add(file.toURL());
+				} catch (MalformedURLException e) {
+					e.printStackTrace();
+				}
+			}
+
+			if (recurse) {
+				File[] directories = libFolder.listFiles(new FileFilter() {
+					public boolean accept(File pathname) {
+						return pathname.isDirectory();
+					}
+				});
+				if (directories != null) {
+					for (int i = 0; i < directories.length; i++) {
+						out.addAll(findResourceRecursive(directories[i], regex, recurse));
+					}
+				}
+			}
+			return out;
+		}
+
+		public BundleContext getBundleContext() {
+			return null;
+		}
+
+		public Map<X509Certificate, List<X509Certificate>> getSignerCertificates(int signersType) {
+			return null;
+		}
+
+		public Version getVersion() {
+			return null;
+		}
+
+		public <A> A adapt(Class<A> type) {
+			return null;
+		}
+
+		public File getDataFile(String filename) {
+			return null;
+		}
+
+	}
+
+	protected class VectorEnumeration<E> implements Enumeration<E> {
+
+		Iterator<E> it;
+
+		VectorEnumeration(Collection<E> col) {
+			it = col.iterator();
+		}
+
+		public boolean hasMoreElements() {
+			return it.hasNext();
+		}
+
+		public E nextElement() {
+			return it.next();
+		}
+	}
+
+	protected class RegexFileFilter implements FileFilter {
+		private String regex;
+
+		RegexFileFilter(String regex) {
+			this.regex = regex.substring(1);
+		}
+
+		public boolean accept(File pathname) {
+			return pathname.getAbsolutePath().endsWith(regex);
 		}
 	}
 }

--- a/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/service/AbstractAcceleoGenerator.java
+++ b/plugins/org.eclipse.acceleo.engine/src/org/eclipse/acceleo/engine/service/AbstractAcceleoGenerator.java
@@ -13,6 +13,7 @@ package org.eclipse.acceleo.engine.service;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -52,6 +53,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.eclipse.emf.ecore.plugin.EcorePlugin.ExtensionProcessor;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.URIConverter;
@@ -460,6 +462,13 @@ public abstract class AbstractAcceleoGenerator {
 
 		// make sure that metamodel projects in the workspace override those in plugins
 		modelResourceSet.getURIConverter().getURIMap().putAll(uriMap);
+
+		if (!EMFPlugin.IS_ECLIPSE_RUNNING) {
+			URLClassLoader classLoader = (URLClassLoader)(Thread.currentThread().getContextClassLoader());
+			ExtensionProcessor.process(classLoader);
+			new AcceleoEnginePlugin().parseExtensionPoints();
+			// processStandaloneClassPath(modulesResourceSet);
+		}
 
 		registerResourceFactories(modelResourceSet);
 		registerPackages(modelResourceSet);


### PR DESCRIPTION
This has been created as a copy of the gerrit review https://git.eclipse.org/r/c/acceleo/org.eclipse.acceleo/+/196038/5. Thereafter is the comment that was set on said gerrit:

https://bugs.eclipse.org/bugs/show_bug.cgi?id=580857

Enable dynamic extensión overloading and overriding mechanism for templates and queries when eclipse is running and not running.

Example project available at https://github.com/perelengo/acceleo-dynamic-overX-test

Can get the compiled project as 3.7.12 version at http://maven3.samsara-software.es/repository/ 3.7.11 also available at this maven repo as SNAPSHOT version.

Have to run maven clean install on org.eclipse.acceleo.module.dynamic_override.parent project to make it work