### PR TITLE
Open Guava ranges to accept v32.1.3 from Eclipse 2023-12

### DIFF
--- a/examples/org.eclipse.acceleo.examples.uml2java/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.acceleo.examples.uml2java/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.acceleo.model;bundle-version="3.3.0",
  org.eclipse.acceleo.profiler;bundle-version="3.3.0",
  org.eclipse.acceleo.engine;bundle-version="3.3.0",
- com.google.guava;bundle-version="[12.0.0,16.0.0)"
+ com.google.guava;bundle-version="[27.0.0,33.0)"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ActivationPolicy: lazy
 Eclipse-LazyStart: true

--- a/examples/org.eclipse.acceleo.module.example.ecore2python/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.acceleo.module.example.ecore2python/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ocl.ecore,
  org.eclipse.acceleo.model,
  org.eclipse.acceleo.engine,
- com.google.guava;bundle-version="[12.0.0,16.0.0)"
+ com.google.guava;bundle-version="[27.0.0,33.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy

--- a/examples/org.eclipse.acceleo.module.example.ecore2unittests/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.acceleo.module.example.ecore2unittests/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.5.0",
  org.eclipse.ocl.ecore,
  org.eclipse.core.runtime,
  org.eclipse.acceleo.engine,
- com.google.guava;bundle-version="[12.0.0,16.0.0)"
+ com.google.guava;bundle-version="[27.0.0,33.0)"
 Export-Package: org.eclipse.acceleo.module.example.ecore2unittests.main,
  org.eclipse.acceleo.module.example.ecore2unittests.services
 Bundle-Vendor: Eclipse Modeling Project

--- a/examples/org.eclipse.acceleo.module.example.uml2java.helios/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.acceleo.module.example.uml2java.helios/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ocl.ecore,
  org.eclipse.acceleo.model,
  org.eclipse.acceleo.engine,
- com.google.guava;bundle-version="[12.0.0,16.0.0)"
+ com.google.guava;bundle-version="[27.0.0,33.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy

--- a/examples/org.eclipse.acceleo.module.example.uml2java/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.acceleo.module.example.uml2java/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ocl.ecore,
  org.eclipse.acceleo.model,
  org.eclipse.acceleo.engine,
- com.google.guava;bundle-version="[12.0.0,16.0.0)"
+ com.google.guava;bundle-version="[27.0.0,33.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.acceleo.common.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.common.ide/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.acceleo.common;bundle-version="3.6.0",
  org.eclipse.emf.ecore
 Export-Package: org.eclipse.acceleo.common.ide.authoring
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)"
 Bundle-Activator: org.eclipse.acceleo.common.ide.AcceleoCommonIDEPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.acceleo.common/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.common/META-INF/MANIFEST.MF
@@ -49,6 +49,6 @@ Require-Bundle: org.eclipse.emf.ecore.xmi,
  org.eclipse.core.runtime;bundle-version="3.4.0";resolution:=optional,
  org.eclipse.core.resources;bundle-version="3.3.0";resolution:=optional,
  org.eclipse.core.filesystem;resolution:=optional
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.acceleo.engine/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.engine/META-INF/MANIFEST.MF
@@ -48,6 +48,6 @@ Export-Package: org.eclipse.acceleo.engine;uses:="org.osgi.framework,org.eclipse
    org.eclipse.acceleo.engine.generation.strategy",
  org.eclipse.acceleo.engine.service.properties;uses:="org.osgi.framework,org.eclipse.acceleo.engine.service",
  org.eclipse.acceleo.engine.utils;uses:="org.eclipse.acceleo.profiler,org.eclipse.emf.ecore.resource"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.acceleo.ide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.ide.ui/META-INF/MANIFEST.MF
@@ -121,6 +121,6 @@ Export-Package: org.eclipse.acceleo.ide.ui;
  org.eclipse.acceleo.internal.ide.ui.wizards.newfile.main;x-internal:=true,
  org.eclipse.acceleo.internal.ide.ui.wizards.newproject;x-friends:="org.eclipse.acceleo.parser.tests",
  org.eclipse.acceleo.internal.ide.ui.wizards.project;x-friends:="org.eclipse.acceleo.ide.ui.tests"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.acceleo.parser/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.parser/META-INF/MANIFEST.MF
@@ -44,5 +44,5 @@ Export-Package: org.eclipse.acceleo.internal.compatibility.parser.ast.ocl.enviro
    org.eclipse.emf.ecore.resource,
    org.eclipse.acceleo.common.interpreter,
    com.google.common.collect"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"

--- a/query/plugins/org.eclipse.acceleo.query.doc/META-INF/MANIFEST.MF
+++ b/query/plugins/org.eclipse.acceleo.query.doc/META-INF/MANIFEST.MF
@@ -10,4 +10,4 @@ Require-Bundle: org.eclipse.acceleo.annotations;bundle-version="3.6.0",
  org.eclipse.acceleo.query;bundle-version="3.6.0",
  org.eclipse.emf.ecore,
  org.eclipse.help,
- com.google.guava;bundle-version="[27.0.0,30.2.0)"
+ com.google.guava;bundle-version="[27.0.0,33.0)"

--- a/query/tests/org.eclipse.acceleo.query.tests/META-INF/MANIFEST.MF
+++ b/query/tests/org.eclipse.acceleo.query.tests/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.junit;bundle-version="[4.11.0,5.0.0)",
  org.eclipse.uml2.uml;bundle-version="5.0.1",
  org.eclipse.acceleo.annotations,
  org.eclipse.acceleo.query.tests.nestedpackages,
- com.google.guava;bundle-version="[27.0.0,30.2.0)",
+ com.google.guava;bundle-version="[27.0.0,33.0)",
  org.antlr.runtime;bundle-version="[4.7.2,4.7.3)"
 Bundle-ActivationPolicy: lazy
 Export-Package: nooperationreflection,

--- a/tests/org.eclipse.acceleo.common.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.acceleo.common.tests/META-INF/MANIFEST.MF
@@ -18,4 +18,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi
 Export-Package: org.eclipse.acceleo.common.tests.suite
-Import-Package: com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.collect;version="[27.0.0,33.0)"

--- a/tests/org.eclipse.acceleo.engine.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.acceleo.engine.tests/META-INF/MANIFEST.MF
@@ -20,5 +20,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.acceleo.parser
 Export-Package: org.eclipse.acceleo.engine.tests.mock;x-friends:="org.eclipse.acceleo.dynamic.tests",
  org.eclipse.acceleo.engine.tests.suite;x-friends:="org.eclipse.acceleo.tests"
-Import-Package: com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)"

--- a/tests/org.eclipse.acceleo.standalone.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.acceleo.standalone.tests/META-INF/MANIFEST.MF
@@ -10,4 +10,4 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.acceleo.parser,
  org.eclipse.acceleo.engine,
  org.junit;bundle-version="4.11.0",
- com.google.guava;bundle-version="[27.0.0,30.2.0)"
+ com.google.guava;bundle-version="[27.0.0,33.0)"


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=582645