### PR TITLE
Complete the switch to Guava 33

### DIFF
--- a/plugins/org.eclipse.acceleo.common.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.common.ide/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.acceleo.common;bundle-version="3.6.0",
  org.eclipse.emf.ecore
 Export-Package: org.eclipse.acceleo.common.ide.authoring
-Import-Package: com.google.common.base;version="[27.0.0,33.0.0)",
- com.google.common.collect;version="[27.0.0,33.0.0)",
- com.google.common.io;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.base;version="[27.0.0,34.0.0)",
+ com.google.common.collect;version="[27.0.0,34.0.0)",
+ com.google.common.io;version="[27.0.0,34.0.0)"
 Bundle-Activator: org.eclipse.acceleo.common.ide.AcceleoCommonIDEPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.acceleo.common/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.common/META-INF/MANIFEST.MF
@@ -49,6 +49,6 @@ Require-Bundle: org.eclipse.emf.ecore.xmi,
  org.eclipse.core.runtime;bundle-version="3.4.0";resolution:=optional,
  org.eclipse.core.resources;bundle-version="3.3.0";resolution:=optional,
  org.eclipse.core.filesystem;resolution:=optional
-Import-Package: com.google.common.base;version="[27.0.0,33.0.0)",
- com.google.common.collect;version="[27.0.0,33.0.0)",
- com.google.common.io;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.base;version="[27.0.0,34.0.0)",
+ com.google.common.collect;version="[27.0.0,34.0.0)",
+ com.google.common.io;version="[27.0.0,34.0.0)"

--- a/plugins/org.eclipse.acceleo.engine/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.engine/META-INF/MANIFEST.MF
@@ -48,6 +48,6 @@ Export-Package: org.eclipse.acceleo.engine;uses:="org.osgi.framework,org.eclipse
    org.eclipse.acceleo.engine.generation.strategy",
  org.eclipse.acceleo.engine.service.properties;uses:="org.osgi.framework,org.eclipse.acceleo.engine.service",
  org.eclipse.acceleo.engine.utils;uses:="org.eclipse.acceleo.profiler,org.eclipse.emf.ecore.resource"
-Import-Package: com.google.common.base;version="[27.0.0,33.0.0)",
- com.google.common.collect;version="[27.0.0,33.0.0)",
- com.google.common.io;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.base;version="[27.0.0,34.0.0)",
+ com.google.common.collect;version="[27.0.0,34.0.0)",
+ com.google.common.io;version="[27.0.0,34.0.0)"

--- a/plugins/org.eclipse.acceleo.ide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.ide.ui/META-INF/MANIFEST.MF
@@ -121,6 +121,6 @@ Export-Package: org.eclipse.acceleo.ide.ui;
  org.eclipse.acceleo.internal.ide.ui.wizards.newfile.main;x-internal:=true,
  org.eclipse.acceleo.internal.ide.ui.wizards.newproject;x-friends:="org.eclipse.acceleo.parser.tests",
  org.eclipse.acceleo.internal.ide.ui.wizards.project;x-friends:="org.eclipse.acceleo.ide.ui.tests"
-Import-Package: com.google.common.base;version="[27.0.0,33.0.0)",
- com.google.common.collect;version="[27.0.0,33.0.0)",
- com.google.common.io;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.base;version="[27.0.0,34.0.0)",
+ com.google.common.collect;version="[27.0.0,34.0.0)",
+ com.google.common.io;version="[27.0.0,34.0.0)"

--- a/plugins/org.eclipse.acceleo.parser/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.acceleo.parser/META-INF/MANIFEST.MF
@@ -44,5 +44,5 @@ Export-Package: org.eclipse.acceleo.internal.compatibility.parser.ast.ocl.enviro
    org.eclipse.emf.ecore.resource,
    org.eclipse.acceleo.common.interpreter,
    com.google.common.collect"
-Import-Package: com.google.common.base;version="[27.0.0,33.0.0)",
- com.google.common.collect;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.base;version="[27.0.0,34.0.0)",
+ com.google.common.collect;version="[27.0.0,34.0.0)"

--- a/query/tests/org.eclipse.acceleo.query.compat.tests/META-INF/MANIFEST.MF
+++ b/query/tests/org.eclipse.acceleo.query.compat.tests/META-INF/MANIFEST.MF
@@ -23,5 +23,5 @@ Require-Bundle: org.junit;bundle-version="[4.11.0,5.0.0)",
  org.eclipse.acceleo.query.tests.qmodel
 Export-Package: org.eclipse.acceleo.query.compat.tests;x-friends:="org.eclipse.acceleo.query.tests.qmodel.editor",
  org.eclipse.acceleo.query.compat.tests.unit;x-friends:="org.eclipse.acceleo.query.tests.qmodel.editor"
-Import-Package: com.google.common.collect;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.collect;version="[27.0.0,34.0.0)"
 

--- a/tests/org.eclipse.acceleo.common.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.acceleo.common.tests/META-INF/MANIFEST.MF
@@ -18,4 +18,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi
 Export-Package: org.eclipse.acceleo.common.tests.suite
-Import-Package: com.google.common.collect;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.collect;version="[27.0.0,34.0.0)"

--- a/tests/org.eclipse.acceleo.engine.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.acceleo.engine.tests/META-INF/MANIFEST.MF
@@ -20,5 +20,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.acceleo.parser
 Export-Package: org.eclipse.acceleo.engine.tests.mock;x-friends:="org.eclipse.acceleo.dynamic.tests",
  org.eclipse.acceleo.engine.tests.suite;x-friends:="org.eclipse.acceleo.tests"
-Import-Package: com.google.common.collect;version="[27.0.0,33.0.0)",
- com.google.common.io;version="[27.0.0,33.0.0)"
+Import-Package: com.google.common.collect;version="[27.0.0,34.0.0)",
+ com.google.common.io;version="[27.0.0,34.0.0)"


### PR DESCRIPTION
The previous patches updated the `Require-Bundle` ranges, but not the `Import-Package`.
