### PR TITLE
Fix formatting in template documentation

### DIFF
--- a/plugins/org.eclipse.acceleo.aql.doc/pages/index.adoc
+++ b/plugins/org.eclipse.acceleo.aql.doc/pages/index.adoc
@@ -476,7 +476,7 @@ The template signature must include the visibility and the name, and can optiona
 <template documentation>
 @param class <documentation of the parameter>
 /]
-[template public generate(class : ecore::EClass) post (self.trim())]
+[template public generate(class : ecore::EClass) post(self.trim())]
 [/template]
 ----
 
@@ -855,7 +855,7 @@ Also a <<module-2,Module>> can contain a template used as entry point of the gen
 ----
 <<template-2,Template>> =
 
-'[template ' <<visibility,Visibility>> <<identifier,Identifier>> '(' <<parameter,Parameter>>(',' <<parameter,Parameter>>)* ')' ('post (' <<aql-expression,AQL Expression>> ')')? ']'
+'[template ' <<visibility,Visibility>> <<identifier,Identifier>> '(' <<parameter,Parameter>>(',' <<parameter,Parameter>>)* ')' ('post(' <<aql-expression,AQL Expression>> ')')? ']'
 
 (<<statement,Statement>>)*
 


### PR DESCRIPTION
There must not be a space between `post` and `(`.

<img width="695" height="70" alt="Screenshot 2026-03-28 at 16 44 52" src="https://github.com/user-attachments/assets/a6b8935f-f3e5-43c3-8042-1d7b4c0b802f" />
