### PR TITLE
Fix formatting in template documentation

### DIFF
--- a/plugins/org.eclipse.acceleo.aql.doc/pages/index.adoc
+++ b/plugins/org.eclipse.acceleo.aql.doc/pages/index.adoc
@@ -1401,13 +1401,13 @@ Acceleo 4 does not allow pre-conditions on templates.
 Acceleo 3 used an implicit String-typed variable so the post expression could be a simple call without a variable:
 
 ----
-[template public aTemplateName(...) post (trim())]
+[template public aTemplateName(...) post(trim())]
 ----
 
 Acceleo 4 doesn't allow implicit variables. The result of the template call will be stored in the `self` variable and the migration will thus transform this expression into:
 
 ----
-[template public aTemplateName(...) post (self.trim())]
+[template public aTemplateName(...) post(self.trim())]
 ----
 
 ===== Init block

--- a/plugins/org.eclipse.acceleo.aql.doc/pages/index.adoc
+++ b/plugins/org.eclipse.acceleo.aql.doc/pages/index.adoc
@@ -476,7 +476,7 @@ The template signature must include the visibility and the name, and can optiona
 <template documentation>
 @param class <documentation of the parameter>
 /]
-[template public generate(class : ecore::EClass) post (self.trim())]
+[template public generate(class : ecore::EClass) post(self.trim())]
 [/template]
 ----
 
@@ -855,7 +855,7 @@ Also a <<module-2,Module>> can contain a template used as entry point of the gen
 ----
 <<template-2,Template>> =
 
-'[template ' <<visibility,Visibility>> <<identifier,Identifier>> '(' <<parameter,Parameter>>(',' <<parameter,Parameter>>)* ')' ('post (' <<aql-expression,AQL Expression>> ')')? ']'
+'[template ' <<visibility,Visibility>> <<identifier,Identifier>> '(' <<parameter,Parameter>>(',' <<parameter,Parameter>>)* ')' ('post(' <<aql-expression,AQL Expression>> ')')? ']'
 
 (<<statement,Statement>>)*
 


### PR DESCRIPTION
There must not be a space between `post` and the following `(`.

<img width="695" height="70" alt="Screenshot 2026-03-28 at 16 44 52" src="https://github.com/user-attachments/assets/36938c6c-af42-4bb6-8860-35df55bc3b2e" />

That is

Invalid: `[template private name(feature : ecore::EStructuralFeature) post (self.trim())]`
Valid: `[template private name(feature : ecore::EStructuralFeature) post(self.trim())]`

In case the error is due to a bug, this PR is still relevant until fixed. I struggled for a while to understand that "missing ]" means no space between `post` and `(`.